### PR TITLE
Updated manifest and tab callbacks.

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,27 +1,25 @@
-chrome.browserAction.onClicked.addListener(function() { 
+chrome.browserAction.onClicked.addListener(function() {
   chrome.browserAction.getBadgeText({},function(result){
     if(result == "off"){
       chrome.browserAction.setBadgeText({text:''});
     } else {
-      chrome.browserAction.setBadgeText({text:'off'}); 
+      chrome.browserAction.setBadgeText({text:'off'});
     }
     chrome.tabs.getSelected(null, function(tab) {
       var code = 'window.location.reload();';
       chrome.tabs.executeScript(tab.id, {code: code});
     });
-  });  
+  });
 });
 
-chrome.tabs.onUpdated.addListener(function(tabId, changeInfo) {
+chrome.tabs.onUpdated.addListener(function(tab, changeInfo) {
   if (changeInfo.status === 'complete') {
     chrome.browserAction.getBadgeText({},function(result){
       if(result != "off"){
-        chrome.tabs.executeScript(tabId, {
+        chrome.tabs.executeScript(tab.id, {
             file: "var_dumpling.js"
-        });
+        }, function(results){ console.log(results); });
       }
     });
   }
 });
-
-

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -13,13 +13,13 @@
   "browser_action": {
     "default_icon": "images/icon.png"
   },
-  "icons": { 
+  "icons": {
           "16": "images/icon16.png",
           "48": "images/icon48.png",
-          "128": "images/icon128.png" 
+          "128": "images/icon128.png"
         },
   "permissions": [
-    "tabs", "http://*/*"
-    
+    "activeTab",
+    "*://*/*"
   ]
 }


### PR DESCRIPTION
@alexnaspo

This should fix #13 and on my system resolves all errors in chrome.  It contains just some syntactical changes of `tabId` to `tab.id` and adds a callback function for the `var_dumplings.js` script.

``` JavaScript
chrome.tabs.executeScript(tab.id, {
    file: "var_dumpling.js"
}, function(results){ console.log(results); });
```

Thanks for your review!

-EDIT

This also includes changes to `permissions` in `manifest.json` using `activeTab` instead of `tabs`.  Both will work, but I felt `activeTab` was sufficient with `*://*/*` for backwards compatibility.
