### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-#var_dumpling
+# var_dumpling
 ===================
 
 A Google Chrome extension that beautifies your var_dumps and makes 
 them easier for humans to comprehend automatically. No pre tags and no libraries needed!
 
-##Example var_dumpling
+## Example var_dumpling
 ![Alt text](https://raw.github.com/alexnaspo/var_dumpling/master/chrome/images/example.jpg)
 
-##Installation
+## Installation
 
-###Google Chrome
+### Google Chrome
 
 **Web Store**
   +  Download for free [here](https://chrome.google.com/webstore/detail/vardumpling/aikblkmigebodlhkdepmfmgdgmbokkdn?hl=en&gl=US).
@@ -18,7 +18,7 @@ them easier for humans to comprehend automatically. No pre tags and no libraries
   +  On the chrome extensions page (chrome://chrome/extensions/) (make sure you have 'Developer Mode' checked)
   +  click "Load unpacked extension.." and load the chrome directory.
 
-###Firefox###
+### Firefox ###
 
 **Development**
   +  Go to the add-ons manager (cmd shift A for OSX)
@@ -28,7 +28,7 @@ them easier for humans to comprehend automatically. No pre tags and no libraries
 **Web Store**
   +  [Coming soon - after testing] 
 
-##Support
+## Support
 Please feel free to create an issue for any problems you may find. If the issue
 is assosiated with a specific var_dump, please include it (if possible). Any help 
 would be greatly appreciated!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
